### PR TITLE
Fix yReport class option { noFrenchBullet } causing compile error

### DIFF
--- a/classes/yreport/yreport.cls
+++ b/classes/yreport/yreport.cls
@@ -52,7 +52,7 @@
 	\FrenchBullettrue
 }
 \DeclareOption{noFrenchBullet}{
-	\yFrenchBulletfalse
+	\FrenchBulletfalse
 }
 
 \newif\ifFrench


### PR DESCRIPTION
# Hotfix for `yReport` class option 'noFrenchBullet'

## The issue being fixed

Compiling the `yReport` class with the class option **noFrenchBullet** fails with the following error:

> Undefined control sequence.
> \ds@noFrenchBullet -> \yFrenchBulletfalse

## Changes made to fix the issue

- Rename `\yFrenchBulletfalse` to `\FrenchBulletfalse`
